### PR TITLE
Implement proxy helper logic and fix http client

### DIFF
--- a/cpp/include/quickgrab/service/ProxyService.hpp
+++ b/cpp/include/quickgrab/service/ProxyService.hpp
@@ -6,6 +6,7 @@
 #include <boost/asio/steady_timer.hpp>
 #include <chrono>
 #include <functional>
+#include <mutex>
 #include <memory>
 #include <string>
 #include <vector>
@@ -18,6 +19,7 @@ public:
 
     void scheduleRefresh(std::function<std::vector<proxy::ProxyEndpoint>()> callback,
                          std::chrono::minutes cadence);
+    void addProxies(std::vector<proxy::ProxyEndpoint> proxies);
     std::vector<proxy::ProxyEndpoint> listProxies() const;
 
 private:
@@ -28,6 +30,8 @@ private:
     std::function<std::vector<proxy::ProxyEndpoint>()> refreshCallback_;
     std::chrono::minutes cadence_{0};
     std::unique_ptr<boost::asio::steady_timer> timer_;
+    mutable std::mutex snapshotMutex_;
+    std::vector<proxy::ProxyEndpoint> snapshot_;
 };
 
 } // namespace quickgrab::service

--- a/cpp/include/quickgrab/util/HttpClient.hpp
+++ b/cpp/include/quickgrab/util/HttpClient.hpp
@@ -34,7 +34,11 @@ public:
                        const std::vector<Header>& headers,
                        const std::string& body,
                        const std::string& affinityKey,
-                       std::chrono::seconds timeout,\n                       bool followRedirects = false,\n                       unsigned int maxRedirects = 5,\n                       std::string* effectiveUrl = nullptr);
+                       std::chrono::seconds timeout,
+                       bool followRedirects = false,
+                       unsigned int maxRedirects = 5,
+                       std::string* effectiveUrl = nullptr,
+                       bool useProxy = false);
 
 private:
     boost::asio::io_context& io_;
@@ -43,6 +47,4 @@ private:
 };
 
 } // namespace quickgrab::util
-
-
 

--- a/cpp/src/util/HttpClient.cpp
+++ b/cpp/src/util/HttpClient.cpp
@@ -211,21 +211,6 @@ HttpClient::HttpResponse HttpClient::fetch(HttpRequest request,
     return response;
 }
 
-    boost::beast::tcp_stream stream(io_);
-    stream.expires_after(timeout);
-    stream.connect(results);
-    boost::beast::http::write(stream, request);
-    boost::beast::flat_buffer buffer;
-    HttpResponse response;
-    boost::beast::http::read(stream, buffer, response);
-    boost::system::error_code ec;
-    stream.socket().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
-    if (ec && ec != boost::asio::error::not_connected) {
-        throw boost::system::system_error(ec);
-    }
-    return response;
-}
-
 HttpClient::HttpResponse HttpClient::fetch(const std::string& method,
                                            const std::string& url,
                                            const std::vector<Header>& headers,


### PR DESCRIPTION
## Summary
- add local helpers in the proxy controller to normalize proxy flags and affinity keys
- extend ProxyService to accept manual proxy lists and expose a thread-safe snapshot
- clean up the HttpClient interface and eliminate duplicated request logic

## Testing
- cmake -S cpp -B cpp/build *(fails: missing Boost development package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8d6e846483309c3a3a03b8fb3400