### PR TITLE
feat: add IP proxy support with latency selection

### DIFF
--- a/cpp/include/quickgrab/proxy/ProxyPool.hpp
+++ b/cpp/include/quickgrab/proxy/ProxyPool.hpp
@@ -17,6 +17,7 @@ struct ProxyEndpoint {
     std::string password;
     std::chrono::steady_clock::time_point nextAvailable{};
     int failureCount{};
+    std::chrono::milliseconds latency{std::chrono::milliseconds::max()};
 };
 
 class ProxyPool {

--- a/cpp/src/controller/ProxyController.cpp
+++ b/cpp/src/controller/ProxyController.cpp
@@ -878,7 +878,8 @@ void ProxyController::handleList(quickgrab::server::RequestContext& ctx) {
             {"username", proxy.username},
             {"password", proxy.password},
             {"nextAvailable", static_cast<std::int64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(proxy.nextAvailable.time_since_epoch()).count())},
-            {"failureCount", proxy.failureCount}
+            {"failureCount", proxy.failureCount},
+            {"latency", static_cast<std::int64_t>(proxy.latency.count())}
         });
     }
     sendJsonResponse(ctx, boost::beast::http::status::ok, boost::json::serialize(payload));
@@ -901,6 +902,13 @@ void ProxyController::handleHydrate(quickgrab::server::RequestContext& ctx) {
             if (auto it = obj.if_contains("port")) endpoint.port = static_cast<std::uint16_t>(it->as_int64());
             if (auto it = obj.if_contains("username")) endpoint.username = it->is_string() ? std::string(it->as_string()) : "";
             if (auto it = obj.if_contains("password")) endpoint.password = it->is_string() ? std::string(it->as_string()) : "";
+            if (auto it = obj.if_contains("latency")) {
+                if (it->is_int64()) {
+                    endpoint.latency = std::chrono::milliseconds(it->as_int64());
+                } else if (it->is_double()) {
+                    endpoint.latency = std::chrono::milliseconds(static_cast<std::int64_t>(it->as_double()));
+                }
+            }
             endpoint.nextAvailable = std::chrono::steady_clock::now();
             proxies.push_back(std::move(endpoint));
         }

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -124,6 +124,13 @@ std::vector<ProxyEndpoint> loadProxiesFromFile(const std::filesystem::path& path
             if (auto it = obj.if_contains("port")) endpoint.port = static_cast<std::uint16_t>(it->as_int64());
             if (auto it = obj.if_contains("username")) endpoint.username = it->is_string() ? std::string(it->as_string()) : "";
             if (auto it = obj.if_contains("password")) endpoint.password = it->is_string() ? std::string(it->as_string()) : "";
+            if (auto it = obj.if_contains("latency")) {
+                if (it->is_int64()) {
+                    endpoint.latency = std::chrono::milliseconds(it->as_int64());
+                } else if (it->is_double()) {
+                    endpoint.latency = std::chrono::milliseconds(static_cast<std::int64_t>(it->as_double()));
+                }
+            }
             endpoint.nextAvailable = std::chrono::steady_clock::now();
             proxies.push_back(std::move(endpoint));
         }

--- a/cpp/src/service/ProxyService.cpp
+++ b/cpp/src/service/ProxyService.cpp
@@ -1,8 +1,82 @@
 #include "quickgrab/service/ProxyService.hpp"
 
+#include <algorithm>
+#include <chrono>
+#include <string>
+
+#include <boost/asio/connect.hpp>
+#include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/steady_timer.hpp>
 
 namespace quickgrab::service {
+namespace {
+
+constexpr std::chrono::milliseconds kLatencyTimeout{1500};
+
+bool proxyLatencyLess(const proxy::ProxyEndpoint& lhs, const proxy::ProxyEndpoint& rhs) {
+    if (lhs.latency == rhs.latency) {
+        return lhs.host < rhs.host;
+    }
+    return lhs.latency < rhs.latency;
+}
+
+std::chrono::milliseconds measureProxyLatency(const proxy::ProxyEndpoint& endpoint) {
+    try {
+        boost::asio::io_context io;
+        boost::asio::ip::tcp::resolver resolver(io);
+        boost::asio::ip::tcp::socket socket(io);
+        boost::asio::steady_timer timer(io);
+        std::chrono::milliseconds latency = std::chrono::milliseconds::max();
+        bool connected = false;
+
+        auto start = std::chrono::steady_clock::now();
+        auto endpoints = resolver.resolve(endpoint.host, std::to_string(endpoint.port));
+
+        boost::asio::async_connect(socket, endpoints,
+                                   [&](const boost::system::error_code& ec,
+                                       const boost::asio::ip::tcp::endpoint&) {
+                                       if (!ec) {
+                                           connected = true;
+                                           latency = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                               std::chrono::steady_clock::now() - start);
+                                           timer.cancel();
+                                       }
+                                   });
+
+        timer.expires_after(kLatencyTimeout);
+        timer.async_wait([&](const boost::system::error_code& ec) {
+            if (!ec) {
+                socket.cancel();
+            }
+        });
+
+        io.run();
+
+        if (connected) {
+            boost::system::error_code ec;
+            socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
+            socket.close(ec);
+            return latency;
+        }
+    } catch (const std::exception&) {
+    }
+    return kLatencyTimeout * 2;
+}
+
+void prepareProxies(std::vector<proxy::ProxyEndpoint>& proxies) {
+    const auto now = std::chrono::steady_clock::now();
+    for (auto& proxy : proxies) {
+        proxy.failureCount = 0;
+        proxy.nextAvailable = now;
+        if (proxy.latency == std::chrono::milliseconds::max() ||
+            proxy.latency <= std::chrono::milliseconds::zero()) {
+            proxy.latency = measureProxyLatency(proxy);
+        }
+    }
+    std::stable_sort(proxies.begin(), proxies.end(), proxyLatencyLess);
+}
+
+} // namespace
 
 ProxyService::ProxyService(boost::asio::io_context& io, proxy::ProxyPool& pool)
     : io_(io)
@@ -20,9 +94,11 @@ void ProxyService::addProxies(std::vector<proxy::ProxyEndpoint> proxies) {
     if (proxies.empty()) {
         return;
     }
+    prepareProxies(proxies);
     {
         std::scoped_lock lock(snapshotMutex_);
         snapshot_.insert(snapshot_.end(), proxies.begin(), proxies.end());
+        std::stable_sort(snapshot_.begin(), snapshot_.end(), proxyLatencyLess);
     }
     pool_.hydrate(std::move(proxies));
 }
@@ -37,6 +113,7 @@ void ProxyService::doRefresh() {
         return;
     }
     auto proxies = refreshCallback_();
+    prepareProxies(proxies);
     {
         std::scoped_lock lock(snapshotMutex_);
         snapshot_ = proxies;

--- a/cpp/static/index.html
+++ b/cpp/static/index.html
@@ -155,8 +155,19 @@
                     <span class="slider round"></span>
                 </label>
             </div>
+            <div class="switch-container">
+                <label for="useIpProxy">使用IP代理</label>
+                <label class="switch">
+                    <input id="useIpProxy" type="checkbox">
+                    <span class="slider round"></span>
+                </label>
+            </div>
         </div>
 
+        <div class="form-group" id="proxySettings" style="display: none;">
+            <label for="proxyAffinity">代理标识</label>
+            <input type="text" id="proxyAffinity" placeholder="留空则自动生成">
+        </div>
 
         <div class="form-group">
             <label for="delay">延迟下单</label>


### PR DESCRIPTION
## Summary
- add an IP proxy toggle and affinity field to the C++ index page and update form handling so proxy options are submitted with tasks
- store proxy latency in the pool, keep per-affinity assignments, and prioritize the fastest available proxy when threads acquire one
- measure and expose proxy latency during proxy refresh/hydration, including support for optional latency hints from uploads and local config

## Testing
- `cmake -S cpp -B cpp/build` *(fails: missing Boost system/json components in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d23e5c1bfc833084cf449326808da2