### PR TITLE
Add guard for concurrent pending drains

### DIFF
--- a/cpp/include/quickgrab/service/GrabService.hpp
+++ b/cpp/include/quickgrab/service/GrabService.hpp
@@ -47,6 +47,7 @@ private:
     proxy::ProxyPool& proxyPool_;
     MailService& mailService_;
     std::unique_ptr<workflow::GrabWorkflow> workflow_;
+    std::atomic<bool> pendingDrainInFlight_{false};
     std::atomic<long> adjustedFactor_;
     long processingTime_;
     std::chrono::system_clock::time_point updateTime_;


### PR DESCRIPTION
## Summary
- add an atomic guard in `GrabService` to prevent concurrent pending drains
- wrap the pending drain workflow in an RAII helper to reset the guard and improve logging
- add error handling around pending request lookup and dispatch

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost (missing: Boost_INCLUDE_DIR system json))*

------
https://chatgpt.com/codex/tasks/task_e_68d2691441348330b5fc89609de53f5c