### PR TITLE
Fix results repository insert to use request id

### DIFF
--- a/cpp/src/repository/ResultsRepository.cpp
+++ b/cpp/src/repository/ResultsRepository.cpp
@@ -372,7 +372,7 @@ void ResultsRepository::insertResult(const model::Result& result) {
         mysqlx::Schema schema = session->getSchema(pool_.schemaName());
         mysqlx::Table table = schema.getTable("results");
         auto responsePayload = result.responseMessage.is_null() ? result.payload : result.responseMessage;
-        table.insert("id",
+        table.insert("request_id",
                     "device_id",
                     "buyer_id",
                     "thread_id",
@@ -475,7 +475,7 @@ std::vector<model::Result> ResultsRepository::findByFilters(
     auto session = pool_.acquire();
     try {
         std::ostringstream sql;
-        sql << "SELECT id, device_id, buyer_id, thread_id, link, cookies, order_info, user_info, order_template, "
+        sql << "SELECT id, request_id, device_id, buyer_id, thread_id, link, cookies, order_info, user_info, order_template, "
             "message, id_number, keyword, "
             "DATE_FORMAT(start_time, '%Y-%m-%d %H:%i:%s') AS start_time, "
             "DATE_FORMAT(end_time,   '%Y-%m-%d %H:%i:%s') AS end_time, "

--- a/src/main/resources/sql/CreateTables.sql
+++ b/src/main/resources/sql/CreateTables.sql
@@ -66,6 +66,7 @@ CREATE TABLE IF NOT EXISTS requests
 CREATE TABLE IF NOT EXISTS results
 (
     id                 INT AUTO_INCREMENT PRIMARY KEY COMMENT '主键，自动递增',
+    request_id         INT COMMENT '关联请求ID',
     device_id          INT NOT NULL COMMENT '设备ID',
     buyer_id           INT NOT NULL COMMENT '抢购者ID',
     thread_id          VARCHAR(50) COMMENT '线程ID',
@@ -88,6 +89,7 @@ CREATE TABLE IF NOT EXISTS results
     actual_earnings    DECIMAL(10, 2) COMMENT '实际收益',
     estimated_earnings DECIMAL(10, 2) COMMENT '预估收益',
     extension          TEXT COMMENT '扩展',
+    FOREIGN KEY (request_id) REFERENCES requests (id),
     FOREIGN KEY (device_id) REFERENCES devices (id),
     FOREIGN KEY (buyer_id) REFERENCES buyers (id)
 ) COMMENT ='存储抢购结果的表';


### PR DESCRIPTION
## Summary
- update the results repository insert to populate request_id and rely on the auto-increment id
- include request_id in the filter query projection so models hydrate the field
- add request_id to the results table definition with a foreign key to requests

## Testing
- mvn -q test *(fails: unable to reach Maven Central to resolve Spring Boot dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d26d35bd7883308b630440e0464462