### PR TITLE
Handle proxy failures with fallback to direct requests

### DIFF
--- a/cpp/include/quickgrab/util/HttpClient.hpp
+++ b/cpp/include/quickgrab/util/HttpClient.hpp
@@ -7,10 +7,32 @@
 #include <boost/beast/http.hpp>
 
 #include <chrono>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
 namespace quickgrab::util {
+
+class ProxyError : public std::runtime_error {
+public:
+    enum class Type {
+        connect_failed,
+        authentication_required,
+    };
+
+    ProxyError(Type type, int status, const std::string& message)
+        : std::runtime_error(message)
+        , type_(type)
+        , status_(status) {}
+
+    [[nodiscard]] Type type() const noexcept { return type_; }
+
+    [[nodiscard]] int status() const noexcept { return status_; }
+
+private:
+    Type type_;
+    int status_;
+};
 
 class HttpClient {
 public:

--- a/cpp/src/util/HttpClient.cpp
+++ b/cpp/src/util/HttpClient.cpp
@@ -238,8 +238,10 @@ HttpClient::HttpResponse HttpClient::fetch(HttpRequest request,
                 boost::beast::http::response<boost::beast::http::empty_body> connectResponse;
                 boost::beast::http::read(lowest, connectBuffer, connectResponse);
                 if (connectResponse.result() != boost::beast::http::status::ok) {
-                    throw std::runtime_error("Proxy CONNECT failed with status " +
-                                             std::to_string(connectResponse.result_int()));
+                    throw ProxyError(ProxyError::Type::connect_failed,
+                                     connectResponse.result_int(),
+                                     "Proxy CONNECT failed with status " +
+                                         std::to_string(connectResponse.result_int()));
                 }
 
                 if (!SSL_set_tlsext_host_name(stream.native_handle(), parsed.host.c_str())) {
@@ -288,7 +290,9 @@ HttpClient::HttpResponse HttpClient::fetch(HttpRequest request,
             }
 
             if (response.result() == boost::beast::http::status::proxy_authentication_required) {
-                throw std::runtime_error("Proxy authentication required");
+                throw ProxyError(ProxyError::Type::authentication_required,
+                                 response.result_int(),
+                                 "Proxy authentication required");
             }
 
             reportSuccess();


### PR DESCRIPTION
## Summary
- add a `ProxyError` exception type so the HTTP client can classify proxy failures
- throw `ProxyError` when CONNECT or proxy authentication fails and let workflow logic react to it
- retry create/reconfirm/add-order flows with new proxies or direct requests after proxy failures and log the fallback steps

## Testing
- cmake -S cpp -B cpp/build *(fails: missing Boost system/json development headers in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3847659808330bb78901484b8f720