### PR TITLE
Authenticate submit requests and refresh remember-me sessions

### DIFF
--- a/cpp/include/quickgrab/controller/SubmitController.hpp
+++ b/cpp/include/quickgrab/controller/SubmitController.hpp
@@ -1,19 +1,21 @@
 #pragma once
 
 #include "quickgrab/server/Router.hpp"
+#include "quickgrab/service/AuthService.hpp"
 #include "quickgrab/service/GrabService.hpp"
 
 namespace quickgrab::controller {
 
 class SubmitController {
 public:
-    explicit SubmitController(service::GrabService& grabService);
+    SubmitController(service::GrabService& grabService, service::AuthService& authService);
     void registerRoutes(quickgrab::server::Router& router);
 
 private:
     void handleSubmitRequest(quickgrab::server::RequestContext& ctx);
 
     service::GrabService& grabService_;
+    service::AuthService& authService_;
 };
 
 } // namespace quickgrab::controller

--- a/cpp/include/quickgrab/service/AuthService.hpp
+++ b/cpp/include/quickgrab/service/AuthService.hpp
@@ -40,6 +40,10 @@ public:
 
     void logout(const std::string& token);
 
+    std::optional<SessionInfo> touchSession(const std::string& token);
+
+    std::string buildSessionCookie(const SessionInfo& session) const;
+
     std::optional<model::Buyer> getBuyerByToken(const std::string& token);
 
 private:

--- a/cpp/src/controller/AuthController.cpp
+++ b/cpp/src/controller/AuthController.cpp
@@ -93,20 +93,6 @@ void sendJsonResponse(quickgrab::server::RequestContext& ctx,
     ctx.response.prepare_payload();
 }
 
-std::string buildSessionCookie(const service::AuthService::SessionInfo& session) {
-    std::ostringstream oss;
-    oss << service::AuthService::kSessionCookie << '=' << session.token << "; Path=/; HttpOnly; SameSite=Lax";
-    if (session.rememberMe) {
-        auto now = std::chrono::system_clock::now();
-        auto ttl = std::chrono::duration_cast<std::chrono::seconds>(session.expiresAt - now);
-        if (ttl.count() < 0) {
-            ttl = std::chrono::seconds{0};
-        }
-        oss << "; Max-Age=" << ttl.count();
-    }
-    return oss.str();
-}
-
 std::string buildExpiredCookie() {
     std::ostringstream oss;
     oss << service::AuthService::kSessionCookie << "=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax";
@@ -145,7 +131,7 @@ void AuthController::handleLogin(quickgrab::server::RequestContext& ctx) {
         return;
     }
 
-    ctx.response.set(boost::beast::http::field::set_cookie, buildSessionCookie(*authResult.session));
+    ctx.response.set(boost::beast::http::field::set_cookie, authService_.buildSessionCookie(*authResult.session));
 
     boost::json::object payload{{"status", "success"},
                                 {"message", "Login successful"},

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -235,7 +235,7 @@ int main(int /*argc*/, char** /*argv*/) {
     controller::StatisticsController statisticsController{statisticsService};
     statisticsController.registerRoutes(*router);
 
-    controller::SubmitController submitController{grabService};
+    controller::SubmitController submitController{grabService, authService};
     submitController.registerRoutes(*router);
 
     controller::ToolController toolController;


### PR DESCRIPTION
## Summary
- validate submit requests against the active session, attach buyer data to the response, and refresh remember-me cookies when necessary
- expose AuthService helpers to refresh session lifetimes and build consistent session cookies
- reuse the shared cookie helper from AuthController and pass AuthService into SubmitController

## Testing
- cmake -S cpp -B cpp/build *(fails: Boost system/json components are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d672e2ac348330a9a62df5402b177a