### PR TITLE
Align createOrder success detection with Java logic

### DIFF
--- a/cpp/src/workflow/GrabWorkflow.cpp
+++ b/cpp/src/workflow/GrabWorkflow.cpp
@@ -312,8 +312,21 @@ GrabResult GrabWorkflow::createOrder(const GrabContext& ctx, const boost::json::
                 }
             }
 
-            result.success = obj.if_contains("isSuccess") && obj.at("isSuccess").as_int64() == 1;
-            if (result.success||result.message == "OK") {
+            bool success = false;
+            if (auto* isSuccess = obj.if_contains("isSuccess"); isSuccess && isSuccess->is_int64()) {
+                success = isSuccess->as_int64() == 1;
+            }
+            if (!success) {
+                if (auto* status = obj.if_contains("status"); status && status->is_object()) {
+                    const auto& statusObj = status->as_object();
+                    if (auto* code = statusObj.if_contains("code"); code && code->is_int64()) {
+                        success = code->as_int64() == 0;
+                    }
+                }
+            }
+
+            result.success = success;
+            if (result.success) {
                 result.shouldContinue = false;
                 result.shouldUpdate = false;
                 return result;


### PR DESCRIPTION
## Summary
- align the C++ createOrder workflow success detection with the Java implementation by checking the isSuccess flag and status code
- remove the fallback that treated a status message of OK as success so retry/update hints match Java behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7873088cc8330bdcf217b37b963d0