### PR TITLE
Refactor API routing and response format

### DIFF
--- a/cpp/include/quickgrab/util/JsonResponse.hpp
+++ b/cpp/include/quickgrab/util/JsonResponse.hpp
@@ -11,9 +11,8 @@
 
 namespace quickgrab::util {
 
-inline std::string makeIsoTimestamp() {
-    const auto now = std::chrono::system_clock::now();
-    const std::time_t time = std::chrono::system_clock::to_time_t(now);
+inline std::string formatIsoTimestamp(std::chrono::system_clock::time_point timePoint) {
+    const std::time_t time = std::chrono::system_clock::to_time_t(timePoint);
     std::tm tm{};
 #if defined(_WIN32)
     gmtime_s(&tm, &time);
@@ -23,6 +22,10 @@ inline std::string makeIsoTimestamp() {
     std::ostringstream oss;
     oss << std::put_time(&tm, "%Y-%m-%dT%H:%M:%SZ");
     return oss.str();
+}
+
+inline std::string makeIsoTimestamp() {
+    return formatIsoTimestamp(std::chrono::system_clock::now());
 }
 
 inline boost::json::object makeSuccessResponse(const boost::json::value& data,

--- a/cpp/include/quickgrab/util/JsonResponse.hpp
+++ b/cpp/include/quickgrab/util/JsonResponse.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <boost/json.hpp>
+
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+namespace quickgrab::util {
+
+inline std::string makeIsoTimestamp() {
+    const auto now = std::chrono::system_clock::now();
+    const std::time_t time = std::chrono::system_clock::to_time_t(now);
+    std::tm tm{};
+#if defined(_WIN32)
+    gmtime_s(&tm, &time);
+#else
+    gmtime_r(&time, &tm);
+#endif
+    std::ostringstream oss;
+    oss << std::put_time(&tm, "%Y-%m-%dT%H:%M:%SZ");
+    return oss.str();
+}
+
+inline boost::json::object makeSuccessResponse(const boost::json::value& data,
+                                               std::string_view endpoint,
+                                               std::string_view message = {}) {
+    boost::json::object envelope;
+    envelope["success"] = true;
+    envelope["timestamp"] = makeIsoTimestamp();
+    if (!endpoint.empty()) {
+        envelope["path"] = endpoint;
+    }
+    if (!message.empty()) {
+        envelope["message"] = message;
+    }
+    envelope["data"] = data;
+    return envelope;
+}
+
+inline boost::json::object makeErrorDetails(std::string_view message,
+                                            const boost::json::value& details,
+                                            std::string_view endpoint) {
+    boost::json::object errorObj;
+    if (!message.empty()) {
+        errorObj["message"] = message;
+    }
+    if (!details.is_null()) {
+        errorObj["details"] = details;
+    }
+
+    boost::json::object envelope;
+    envelope["success"] = false;
+    envelope["timestamp"] = makeIsoTimestamp();
+    if (!endpoint.empty()) {
+        envelope["path"] = endpoint;
+    }
+    envelope["error"] = std::move(errorObj);
+    return envelope;
+}
+
+} // namespace quickgrab::util
+

--- a/cpp/src/controller/AuthController.cpp
+++ b/cpp/src/controller/AuthController.cpp
@@ -106,7 +106,7 @@ AuthController::AuthController(service::AuthService& authService)
 
 void AuthController::registerRoutes(quickgrab::server::Router& router) {
     router.addRoute("POST", "/api/login", [this](auto& ctx) { handleLogin(ctx); });
-    router.addRoute("POST", "/api/logout", [this](auto& ctx) { handleLogout(ctx); });
+    router.addRoute("POST", "/api/session/logout", [this](auto& ctx) { handleLogout(ctx); });
 }
 
 void AuthController::handleLogin(quickgrab::server::RequestContext& ctx) {

--- a/cpp/src/controller/AuthController.cpp
+++ b/cpp/src/controller/AuthController.cpp
@@ -1,4 +1,5 @@
 #include "quickgrab/controller/AuthController.hpp"
+#include "quickgrab/util/JsonResponse.hpp"
 
 #include <boost/beast/http.hpp>
 #include <boost/json.hpp>
@@ -105,8 +106,8 @@ AuthController::AuthController(service::AuthService& authService)
     : authService_(authService) {}
 
 void AuthController::registerRoutes(quickgrab::server::Router& router) {
-    router.addRoute("POST", "/api/login", [this](auto& ctx) { handleLogin(ctx); });
-    router.addRoute("POST", "/api/session/logout", [this](auto& ctx) { handleLogout(ctx); });
+    router.addRoute("POST", "/api/post/auth/login", [this](auto& ctx) { handleLogin(ctx); });
+    router.addRoute("POST", "/api/post/auth/logout", [this](auto& ctx) { handleLogout(ctx); });
 }
 
 void AuthController::handleLogin(quickgrab::server::RequestContext& ctx) {
@@ -124,7 +125,9 @@ void AuthController::handleLogin(quickgrab::server::RequestContext& ctx) {
 
     auto authResult = authService_.authenticate(username, password, rememberMe);
     if (!authResult.success || !authResult.session) {
-        boost::json::object payload{{"status", "error"}, {"message", authResult.message.empty() ? "账号或密码错误" : authResult.message}};
+        std::string message = authResult.message.empty() ? "账号或密码错误" : authResult.message;
+        boost::json::object payload{{"message", message},
+                                    {"reason", authResult.serverError ? "auth.internal_error" : "auth.invalid_credentials"}};
         auto status = authResult.serverError ? boost::beast::http::status::internal_server_error
                                              : boost::beast::http::status::unauthorized;
         sendJsonResponse(ctx, status, payload);
@@ -133,11 +136,24 @@ void AuthController::handleLogin(quickgrab::server::RequestContext& ctx) {
 
     ctx.response.set(boost::beast::http::field::set_cookie, authService_.buildSessionCookie(*authResult.session));
 
-    boost::json::object payload{{"status", "success"},
-                                {"message", "Login successful"},
-                                {"username", authResult.session->buyer.username},
-                                {"accessLevel", authResult.session->buyer.accessLevel},
-                                {"email", authResult.session->buyer.email}};
+    boost::json::object user;
+    user["id"] = authResult.session->buyer.id;
+    user["username"] = authResult.session->buyer.username;
+    user["accessLevel"] = authResult.session->buyer.accessLevel;
+    if (!authResult.session->buyer.email.empty()) {
+        user["email"] = authResult.session->buyer.email;
+    }
+
+    boost::json::object session;
+    session["rememberMe"] = authResult.session->rememberMe;
+    session["expiresAt"] = quickgrab::util::formatIsoTimestamp(authResult.session->expiresAt);
+    session["cookieName"] = std::string(service::AuthService::kSessionCookie);
+
+    boost::json::object payload;
+    payload["message"] = "Login successful";
+    payload["user"] = std::move(user);
+    payload["session"] = std::move(session);
+
     sendJsonResponse(ctx, boost::beast::http::status::ok, payload);
 }
 
@@ -153,7 +169,14 @@ void AuthController::handleLogout(quickgrab::server::RequestContext& ctx) {
     authService_.logout(token);
     ctx.response.set(boost::beast::http::field::set_cookie, buildExpiredCookie());
 
-    boost::json::object payload{{"status", "success"}, {"message", "Logout successful"}};
+    boost::json::object session;
+    session["cleared"] = true;
+    session["cookieName"] = std::string(service::AuthService::kSessionCookie);
+
+    boost::json::object payload;
+    payload["message"] = "Logout successful";
+    payload["session"] = std::move(session);
+
     sendJsonResponse(ctx, boost::beast::http::status::ok, payload);
 }
 

--- a/cpp/src/controller/GrabController.cpp
+++ b/cpp/src/controller/GrabController.cpp
@@ -10,7 +10,7 @@ GrabController::GrabController(service::GrabService& grabService)
     : grabService_(grabService) {}
 
 void GrabController::registerRoutes(quickgrab::server::Router& router) {
-    router.addRoute("POST", "/api/grab/run", [this](auto& ctx) { handleRun(ctx); });
+    router.addRoute("POST", "/api/post/grab/run", [this](auto& ctx) { handleRun(ctx); });
 }
 
 void GrabController::handleRun(quickgrab::server::RequestContext& ctx) {

--- a/cpp/src/controller/ProxyController.cpp
+++ b/cpp/src/controller/ProxyController.cpp
@@ -437,7 +437,7 @@ void ProxyController::registerRoutes(quickgrab::server::Router& router) {
     router.addRoute("POST", "/api/post/upload", [this](auto& ctx) { handleUpload(ctx); });
     router.addRoute("GET", "/api/get/expand", [this](auto& ctx) { handleExpand(ctx); });
     router.addRoute("GET", "/api/get/item/sku-info", [this](auto& ctx) { handleGetItemSkuInfo(ctx); });
-    router.addRoute("POST", "/api/loginbyvcode", [this](auto& ctx) { handleLoginByVcode(ctx); });
+    router.addRoute("POST", "/api/post/auth/login/vcode", [this](auto& ctx) { handleLoginByVcode(ctx); });
     router.addRoute("POST", "/api/get/cart/list", [this](auto& ctx) { handleGetListCart(ctx); });
     router.addRoute("POST", "/api/get/cart/user-info", [this](auto& ctx) { handleGetUserInfo(ctx); });
     router.addRoute("POST", "/api/get/cart/order-data", [this](auto& ctx) { handleGetAddOrderData(ctx); });

--- a/cpp/src/controller/ProxyController.cpp
+++ b/cpp/src/controller/ProxyController.cpp
@@ -434,14 +434,14 @@ ProxyController::ProxyController(util::HttpClient& client)
     : httpClient_(client) {}
 
 void ProxyController::registerRoutes(quickgrab::server::Router& router) {
-    router.addRoute("POST", "/api/upload", [this](auto& ctx) { handleUpload(ctx); });
-    router.addRoute("GET", "/api/expand", [this](auto& ctx) { handleExpand(ctx); });
-    router.addRoute("GET", "/api/getItemSkuInfo", [this](auto& ctx) { handleGetItemSkuInfo(ctx); });
+    router.addRoute("POST", "/api/post/upload", [this](auto& ctx) { handleUpload(ctx); });
+    router.addRoute("GET", "/api/get/expand", [this](auto& ctx) { handleExpand(ctx); });
+    router.addRoute("GET", "/api/get/item/sku-info", [this](auto& ctx) { handleGetItemSkuInfo(ctx); });
     router.addRoute("POST", "/api/loginbyvcode", [this](auto& ctx) { handleLoginByVcode(ctx); });
-    router.addRoute("POST", "/api/getListCart", [this](auto& ctx) { handleGetListCart(ctx); });
-    router.addRoute("POST", "/api/getUserInfo", [this](auto& ctx) { handleGetUserInfo(ctx); });
-    router.addRoute("POST", "/api/getAddOrderData", [this](auto& ctx) { handleGetAddOrderData(ctx); });
-    router.addRoute("POST", "/api/proxy", [this](auto& ctx) { handleProxyRequest(ctx); });
+    router.addRoute("POST", "/api/get/cart/list", [this](auto& ctx) { handleGetListCart(ctx); });
+    router.addRoute("POST", "/api/get/cart/user-info", [this](auto& ctx) { handleGetUserInfo(ctx); });
+    router.addRoute("POST", "/api/get/cart/order-data", [this](auto& ctx) { handleGetAddOrderData(ctx); });
+    router.addRoute("POST", "/api/post/proxy", [this](auto& ctx) { handleProxyRequest(ctx); });
 }
 
 void ProxyController::handleUpload(quickgrab::server::RequestContext& ctx) {

--- a/cpp/src/controller/QueryController.cpp
+++ b/cpp/src/controller/QueryController.cpp
@@ -207,15 +207,15 @@ QueryController::QueryController(service::QueryService& queryService)
     : queryService_(queryService) {}
 
 void QueryController::registerRoutes(quickgrab::server::Router& router) {
-    router.addRoute("GET", "/api/grab/pending", [this](auto& ctx) { handlePending(ctx); });
+    router.addRoute("GET", "/api/get/grab/pending", [this](auto& ctx) { handlePending(ctx); });
 
     auto bindGetRequests = [this](auto& ctx) { handleGetRequests(ctx); };
     router.addRoute("GET", "/getRequests", bindGetRequests);
-    router.addRoute("GET", "/api/getRequests", bindGetRequests);
+    router.addRoute("GET", "/api/get/requests", bindGetRequests);
 
     auto bindGetResults = [this](auto& ctx) { handleGetResults(ctx); };
     router.addRoute("GET", "/getResults", bindGetResults);
-    router.addRoute("GET", "/api/getResults", bindGetResults);
+    router.addRoute("GET", "/api/get/results", bindGetResults);
     auto bindDeleteRequest = [this](auto& ctx) {
         auto it = ctx.pathParameters.find("id");
         if (it == ctx.pathParameters.end()) {
@@ -229,7 +229,7 @@ void QueryController::registerRoutes(quickgrab::server::Router& router) {
         }
     };
     router.addRoute("DELETE", "/deleteRequest/:id", bindDeleteRequest);
-    router.addRoute("DELETE", "/api/deleteRequest/:id", bindDeleteRequest);
+    router.addRoute("DELETE", "/api/delete/request/:id", bindDeleteRequest);
 
     auto bindDeleteResult = [this](auto& ctx) {
         auto it = ctx.pathParameters.find("id");
@@ -244,7 +244,7 @@ void QueryController::registerRoutes(quickgrab::server::Router& router) {
         }
     };
     router.addRoute("DELETE", "/deleteResult/:id", bindDeleteResult);
-    router.addRoute("DELETE", "/api/deleteResult/:id", bindDeleteResult);
+    router.addRoute("DELETE", "/api/delete/result/:id", bindDeleteResult);
 
     auto bindGetResult = [this](auto& ctx) {
         auto it = ctx.pathParameters.find("id");
@@ -259,11 +259,11 @@ void QueryController::registerRoutes(quickgrab::server::Router& router) {
         }
     };
     router.addRoute("GET", "/getResult/:id", bindGetResult);
-    router.addRoute("GET", "/api/getResult/:id", bindGetResult);
+    router.addRoute("GET", "/api/get/result/:id", bindGetResult);
 
     auto bindGetBuyers = [this](auto& ctx) { handleGetBuyers(ctx); };
     router.addRoute("GET", "/getBuyer", bindGetBuyers);
-    router.addRoute("GET", "/api/getBuyer", bindGetBuyers);
+    router.addRoute("GET", "/api/get/buyers", bindGetBuyers);
 }
 
 void QueryController::handlePending(quickgrab::server::RequestContext& ctx) {

--- a/cpp/src/controller/StatisticsController.cpp
+++ b/cpp/src/controller/StatisticsController.cpp
@@ -83,10 +83,10 @@ StatisticsController::StatisticsController(service::StatisticsService& statistic
     : statisticsService_(statisticsService) {}
 
 void StatisticsController::registerRoutes(quickgrab::server::Router& router) {
-    router.addRoute("GET", "/api/statistics", [this](auto& ctx) { handleStatistics(ctx); });
-    router.addRoute("GET", "/api/dailyStats", [this](auto& ctx) { handleDailyStats(ctx); });
-    router.addRoute("GET", "/api/hourlyStats", [this](auto& ctx) { handleHourlyStats(ctx); });
-    router.addRoute("GET", "/api/buyers", [this](auto& ctx) { handleBuyers(ctx); });
+    router.addRoute("GET", "/api/get/statistics", [this](auto& ctx) { handleStatistics(ctx); });
+    router.addRoute("GET", "/api/get/statistics/daily", [this](auto& ctx) { handleDailyStats(ctx); });
+    router.addRoute("GET", "/api/get/statistics/hourly", [this](auto& ctx) { handleHourlyStats(ctx); });
+    router.addRoute("GET", "/api/get/statistics/buyers", [this](auto& ctx) { handleBuyers(ctx); });
 }
 
 static std::optional<std::string> normalizeIsoToMysql(std::optional<std::string> iso) {

--- a/cpp/src/controller/SubmitController.cpp
+++ b/cpp/src/controller/SubmitController.cpp
@@ -450,7 +450,7 @@ SubmitController::SubmitController(service::GrabService& grabService,
     , httpClient_(httpClient) {}
 
 void SubmitController::registerRoutes(quickgrab::server::Router& router) {
-    router.addRoute("POST", "/api/submitRequest", [this](auto& ctx) { handleSubmitRequest(ctx); });
+    router.addRoute("POST", "/api/submit/request", [this](auto& ctx) { handleSubmitRequest(ctx); });
 }
 
 void SubmitController::handleSubmitRequest(quickgrab::server::RequestContext& ctx) {

--- a/cpp/src/controller/ToolController.cpp
+++ b/cpp/src/controller/ToolController.cpp
@@ -613,19 +613,19 @@ ToolController::ToolController(quickgrab::util::HttpClient& httpClient)
 void ToolController::registerRoutes(quickgrab::server::Router& router) {
     auto bindGetNote = [this](auto& ctx) { handleGetNote(ctx); };
     router.addRoute("POST", "/getNote", bindGetNote);
-    router.addRoute("POST", "/api/getNote", bindGetNote);
+    router.addRoute("POST", "/api/get/order/note", bindGetNote);
 
     auto bindFetchItemInfo = [this](auto& ctx) { handleFetchItemInfo(ctx); };
     router.addRoute("POST", "/fetchItemInfo", bindFetchItemInfo);
-    router.addRoute("POST", "/api/fetchItemInfo", bindFetchItemInfo);
+    router.addRoute("POST", "/api/get/item/details", bindFetchItemInfo);
 
     auto bindCheckCookies = [this](auto& ctx) { handleCheckCookies(ctx); };
     router.addRoute("GET", "/checkCookiesValidity", bindCheckCookies);
-    router.addRoute("GET", "/api/checkCookiesValidity", bindCheckCookies);
+    router.addRoute("GET", "/api/get/cookies/validity", bindCheckCookies);
 
     auto bindCheckLatency = [this](auto& ctx) { handleCheckLatency(ctx); };
     router.addRoute("POST", "/checkLatency", bindCheckLatency);
-    router.addRoute("POST", "/api/checkLatency", bindCheckLatency);
+    router.addRoute("POST", "/api/get/network/latency", bindCheckLatency);
 }
 
 void ToolController::handleGetNote(quickgrab::server::RequestContext& ctx) {

--- a/cpp/src/controller/UserController.cpp
+++ b/cpp/src/controller/UserController.cpp
@@ -59,7 +59,7 @@ UserController::UserController(service::AuthService& authService)
     : authService_(authService) {}
 
 void UserController::registerRoutes(quickgrab::server::Router& router) {
-    router.addRoute("GET", "/api/user", [this](auto& ctx) { handleGetUser(ctx); });
+    router.addRoute("GET", "/api/get/user", [this](auto& ctx) { handleGetUser(ctx); });
 }
 
 void UserController::handleGetUser(quickgrab::server::RequestContext& ctx) {

--- a/cpp/src/server/HttpServer.cpp
+++ b/cpp/src/server/HttpServer.cpp
@@ -121,9 +121,6 @@ private:
         }
 
         std::string target(ctx.request.target());
-        if (target == "/api/login" || target == "/api/loginbyvcode") {
-            return;
-        }
 
         if (auto header = response.find("X-Api-Envelope"); header != response.end()) {
             std::string flag = toLower(std::string(header->value()));

--- a/cpp/src/server/HttpServer.cpp
+++ b/cpp/src/server/HttpServer.cpp
@@ -1,14 +1,20 @@
 #include "quickgrab/server/HttpServer.hpp"
 #include "quickgrab/server/Router.hpp"
 #include "quickgrab/server/RequestContext.hpp"
+#include "quickgrab/util/JsonResponse.hpp"
 
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
 #include <boost/beast/version.hpp>
+#include <boost/json.hpp>
+
+#include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <utility>
 
@@ -64,6 +70,8 @@ private:
             }
         }
 
+        wrapJsonEnvelope(ctx);
+
         auto response = std::make_shared<RequestContext::HttpResponse>(std::move(ctx.response));
         boost::beast::http::async_write(stream_, *response,
             boost::asio::bind_executor(stream_.get_executor(),
@@ -84,6 +92,73 @@ private:
         boost::system::error_code ec;
         stream_.socket().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
         stream_.socket().close(ec);
+    }
+
+    void wrapJsonEnvelope(RequestContext& ctx) {
+        auto& response = ctx.response;
+        if (response.body().empty()) {
+            return;
+        }
+
+        auto contentTypeIt = response.find(boost::beast::http::field::content_type);
+        if (contentTypeIt == response.end()) {
+            return;
+        }
+
+        std::string contentType = std::string(contentTypeIt->value());
+        auto toLower = [](std::string value) {
+            std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+                return static_cast<char>(std::tolower(ch));
+            });
+            return value;
+        };
+
+        if (contentType.find("application/json") == std::string::npos) {
+            std::string lowered = toLower(contentType);
+            if (lowered.find("application/json") == std::string::npos) {
+                return;
+            }
+        }
+
+        std::string target(ctx.request.target());
+        if (target == "/api/login" || target == "/api/loginbyvcode") {
+            return;
+        }
+
+        if (auto header = response.find("X-Api-Envelope"); header != response.end()) {
+            std::string flag = toLower(std::string(header->value()));
+            response.erase(header);
+            if (flag == "skip") {
+                return;
+            }
+        }
+
+        bool success = response.result_int() >= 200 && response.result_int() < 400;
+
+        boost::json::value parsed;
+        try {
+            parsed = boost::json::parse(response.body());
+        } catch (const std::exception&) {
+            parsed = boost::json::value(boost::json::string(response.body()));
+        }
+
+        std::string message;
+        if (!success && parsed.is_object()) {
+            const auto& object = parsed.as_object();
+            if (auto it = object.if_contains("message"); it && it->is_string()) {
+                message = std::string(it->as_string().c_str());
+            } else if (auto it = object.if_contains("error"); it && it->is_string()) {
+                message = std::string(it->as_string().c_str());
+            }
+        }
+
+        boost::json::object envelope = success
+            ? quickgrab::util::makeSuccessResponse(parsed, target)
+            : quickgrab::util::makeErrorDetails(message, parsed, target);
+
+        response.body() = boost::json::serialize(envelope);
+        response.set(boost::beast::http::field::content_type, "application/json; charset=utf-8");
+        response.prepare_payload();
     }
 
     boost::beast::tcp_stream stream_;

--- a/cpp/static/cart.html
+++ b/cpp/static/cart.html
@@ -1284,18 +1284,7 @@
 
         // 获取用户信息并保存账号
         try {
-            const response = await fetch('/api/getUserInfo', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                },
-                body: new URLSearchParams({
-                    cookie: cookieStr
-                })
-            });
-
-            const data = await response.json();
-
+            const data = await callCartEndpoint('/api/get/cart/user-info', { cookie: cookieStr });
             if (data.status.code === 0 && data.status.message === 'OK') {
                 const result = data.result;
                 const basic = result.basic || {};
@@ -1332,6 +1321,22 @@
         await fetchUserInfo(cookieStr);
     }
 
+    async function callCartEndpoint(path, params) {
+        const response = await fetch(path, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: new URLSearchParams(params)
+        });
+
+        const payload = await response.json();
+        if (!payload.success || !payload.data) {
+            throw new Error(payload.error?.message || '接口请求失败');
+        }
+        return payload.data;
+    }
+
     // 处理退出登录
     function handleLogout() {
         localStorage.removeItem('cartCookie');
@@ -1345,18 +1350,7 @@
     // 获取购物车数据
     async function fetchCartData(cookie) {
         try {
-            const response = await fetch('/api/getListCart', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                },
-                body: new URLSearchParams({
-                    cookie: cookie
-                })
-            });
-
-            const data = await response.json();
-
+            const data = await callCartEndpoint('/api/get/cart/list', { cookie });
             if (data.status.code === 0) {
                 renderCartData(data.result);
             } else {
@@ -1371,17 +1365,7 @@
     // 获取用户信息
     async function fetchUserInfo(cookie) {
         try {
-            const response = await fetch('/api/getUserInfo', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                },
-                body: new URLSearchParams({
-                    cookie: cookie
-                })
-            });
-
-            const data = await response.json();
+            const data = await callCartEndpoint('/api/get/cart/user-info', { cookie });
 
             if (data.status.code === 0 && data.status.message === 'OK') {
                 const result = data.result;
@@ -1487,18 +1471,10 @@
 
         try {
             // 调用代理接口获取订单数据
-            const response = await fetch('/api/getAddOrderData', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                },
-                body: new URLSearchParams({
-                    cookie: cookie,
-                    link: orderLink
-                })
+            const data = await callCartEndpoint('/api/get/cart/order-data', {
+                cookie: cookie,
+                link: orderLink
             });
-
-            const data = await response.json();
             console.log('订单数据响应:', data);
 
             if (data.order?.status?.code === 0) {

--- a/cpp/static/js/modal-handler.js
+++ b/cpp/static/js/modal-handler.js
@@ -301,14 +301,15 @@ function setupButtonEvents(item, userInfo) {
         deleteButton.onclick = function () {
             const password = prompt('请输入密码：1');
             if (password === "1") {
-                fetch(`/api/deleteRequest/${item.id}`, {method: 'DELETE'})
-                    .then(response => {
-                        if (response.ok) {
+                fetch(`/api/delete/request/${item.id}`, {method: 'DELETE'})
+                    .then(response => response.json())
+                    .then(payload => {
+                        if (payload.success) {
                             showAlert('删除成功', 'success');
                             closeModal();
                             document.querySelector(`.result-item[data-id="${item.id}"]`).remove();
                         } else {
-                            showAlert('删除失败', 'error');
+                            showAlert(payload.error?.message || '删除失败', 'error');
                         }
                     })
                     .catch(error => console.error('删除失败:', error));
@@ -333,10 +334,15 @@ function setupButtonEvents(item, userInfo) {
 
     // 检查Cookies按钮事件
     document.getElementById('checkCookiesButton').onclick = function () {
-        fetch(`/api/checkCookiesValidity?cookies=${encodeURIComponent(item.cookies)}`)
+        fetch(`/api/get/cookies/validity?cookies=${encodeURIComponent(item.cookies)}`)
             .then(response => response.json())
-            .then(data => {
-                showAlert(data.message, 'info');
+            .then(payload => {
+                if (payload.success) {
+                    const message = payload.data?.message || 'Cookies 校验完成';
+                    showAlert(message, 'info');
+                } else {
+                    showAlert(payload.error?.message || '检查失败', 'error');
+                }
             })
             .catch(error => console.error('检查失败:', error));
     };

--- a/cpp/static/js/orderTemplate-handler.js
+++ b/cpp/static/js/orderTemplate-handler.js
@@ -13,22 +13,19 @@ function getOrderTemplate() {
         return;
     }
 
-    fetch('/api/getNote', {
+    fetch('/api/get/order/note', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
         },
         body: JSON.stringify(data),
     })
-        .then(response => {
-            if (!response.ok) {
-                return response.json().then(errorData => {
-                    throw new Error(errorData.status.description);
-                });
+        .then(response => response.json())
+        .then(payload => {
+            if (!payload.success || !payload.data) {
+                throw new Error(payload.error?.message || '接口请求失败');
             }
-            return response.json();
-        })
-        .then(data => {
+            const data = payload.data;
             const status = data.status;
             const result = data.result;
 
@@ -230,19 +227,19 @@ function handleImageUpload(input, item) {
         const formData = new FormData();
         formData.append('file', file);
         formData.append('customCookies', cookies);
-        fetch('/api/upload', {
+        fetch('/api/post/upload', {
             method: 'POST',
             body: formData,
         })
             .then(response => response.json())
-            .then(data => {
-                if (data && data.result && data.result.url) {
+            .then(payload => {
+                if (payload.success && payload.data && payload.data.result && payload.data.result.url) {
                     showAlert('上传成功', 'success')
-                    console.log('上传成功', data);
-                    item.value = data.result.url;
-                    displayImageURL(input, data.result.url);
+                    console.log('上传成功', payload.data);
+                    item.value = payload.data.result.url;
+                    displayImageURL(input, payload.data.result.url);
                 } else {
-                    showAlert('上传失败', 'error');
+                    showAlert(payload.error?.message || '上传失败', 'error');
                 }
             })
             .catch(error => {

--- a/cpp/static/js/time-handler.js
+++ b/cpp/static/js/time-handler.js
@@ -9,27 +9,36 @@ document.addEventListener("DOMContentLoaded", function() {
         .catch(error => console.error('Error during initialization:', error));
 });
 function fetchBuyers() {
-    return fetch('/api/user')
+    return fetch('/api/get/user')
         .then(response => response.json())
-        .then(data => {
+        .then(payload => {
+            if (!payload.success || !payload.data) {
+                throw new Error('无法获取用户信息');
+            }
+            const account = payload.data.account || payload.data;
+
             // 设定邮箱地址
             const emailField = document.getElementById('email');
-            emailField.value = data.email;
+            emailField.value = account.email || '';
 
-            if (data.accessLevel > 3) {
+            if ((account.accessLevel || account.privilegeLevel || 0) > 3) {
                 document.getElementById('buyerSelectList').style.display = 'flex';
             } else {
                 document.getElementById('buyerSelectList').style.display = 'none';
             }
 
-            let currentUser = data.username;
-            return fetch('/api/getBuyer').then(response => ({ response, currentUser }));
+            let currentUser = account.username || account.displayName;
+            return fetch('/api/get/buyers').then(response => ({ response, currentUser }));
         })
         .then(({ response, currentUser }) => response.json().then(data => ({ data, currentUser })))
         .then(({ data, currentUser }) => {
+            if (!data.success || !data.data) {
+                throw new Error('无法获取买家列表');
+            }
+            const buyers = data.data.buyers || data.data.items || [];
             const buyerSelect = document.getElementById('buyerSelect');
             buyerSelect.innerHTML = '<option value="">所有买家</option>';
-            data.forEach(buyer => {
+            buyers.forEach(buyer => {
                 const option = document.createElement('option');
                 option.value = buyer.id;
                 option.textContent = buyer.username;

--- a/cpp/static/js/user.js
+++ b/cpp/static/js/user.js
@@ -1,15 +1,21 @@
 // 获取当前用户信息
 async function fetchUser() {
     try {
-        const response = await fetch('/api/user', {
+        const response = await fetch('/api/get/user', {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json'
             }
         });
         if (response.ok) {
-            const data = await response.json();
-            document.getElementById('username').textContent = data.username;
+            const payload = await response.json();
+            if (payload.success && payload.data) {
+                const account = payload.data.account || payload.data;
+                const displayName = account.displayName || account.username || '未登录';
+                document.getElementById('username').textContent = displayName;
+            } else {
+                console.error('Unexpected user response', payload);
+            }
         } else {
             console.error('Failed to fetch user data');
         }
@@ -21,7 +27,7 @@ async function fetchUser() {
 // 登出功能
 document.getElementById('logout-button').addEventListener('click', async () => {
     try {
-        const response = await fetch('/api/logout', {
+        const response = await fetch('/api/session/logout', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'

--- a/cpp/static/link.html
+++ b/cpp/static/link.html
@@ -208,13 +208,18 @@
         const itemId = itemIdMatch[1];
         globalState.itemId = itemId;
         const param = encodeURIComponent(JSON.stringify({itemId: itemId}));
-        const apiUrl = `/api/getItemSkuInfo?param=${param}`;
+        const apiUrl = `/api/get/item/sku-info?param=${param}`;
 
         try {
             const response = await fetch(apiUrl, {
                 method: 'GET'
             });
-            const data = await response.json();
+            const payload = await response.json();
+            if (!payload.success || !payload.data) {
+                showAlert('API请求失败');
+                return;
+            }
+            const data = payload.data;
 
             if (data.status.code !== 0) {
                 showAlert('API请求失败: ' + data.status.message);

--- a/cpp/static/requests.html
+++ b/cpp/static/requests.html
@@ -186,7 +186,7 @@
 
         const listHandler = new ListHandler({
             containerId: 'requestsContainer',
-            fetchUrl: '/api/getRequests',
+            fetchUrl: '/api/get/requests',
             isRequest: true,
             getStatusText: getRequestStatusText,
             getStatusClass: getRequestStatusClass,

--- a/cpp/static/results.html
+++ b/cpp/static/results.html
@@ -185,7 +185,7 @@
 
         const listHandler = new ListHandler({
             containerId: 'resultsContainer',
-            fetchUrl: '/api/getResults',
+            fetchUrl: '/api/get/results',
             isRequest: false,
             getStatusText: getResultStatusText,
             getStatusClass: getResultStatusClass,


### PR DESCRIPTION
## Summary
- wrap all non-auth JSON responses in a common envelope and expose helpers to simplify building the new structure
- rename C++ routes to the new /api/get and /api/post scheme and adjust controllers accordingly
- update the static frontend to call the renamed endpoints and consume the enveloped payloads across dashboards, carts, and utilities

## Testing
- cmake -S cpp -B cpp/build *(fails: missing Boost system/json components in the container)*

------
https://chatgpt.com/codex/tasks/task_e_69064a4920c0832ea9ed1985b5412f7b